### PR TITLE
main_ds3.py; Change json to Json

### DIFF
--- a/src/main_ds3.py
+++ b/src/main_ds3.py
@@ -78,7 +78,7 @@ working_directory = os.path.dirname(os.path.abspath(__file__))
 os.chdir(working_directory)
 
 def load_json(file_name):
-    file_path = os.path.join(working_directory, "Resources/json", file_name)
+    file_path = os.path.join(working_directory, "Resources/Json", file_name)
     with open(file_path, "r") as f:
         return json.load(f)
 


### PR DESCRIPTION
In main_ds3.py on line 81, on Linux, "json" (with a lower-case j) was causing the program to not find its json files, due to a case mismatch with the folder it's referring to. Making it an uppercase J fixed the issue.